### PR TITLE
ci: Remove set up python step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
       - name: Install dependencies
         run: |
           ./macos/bootstrap.sh
@@ -83,10 +79,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
       - name: Install dependencies
         run: |
           ./macos/bootstrap.sh
@@ -130,10 +122,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
       - name: Set up environment
         run: |
           cp .env.ci .env


### PR DESCRIPTION
The set up python step in the release CI just causes unpredictable problems. This commit removes the step from the build process for every runner.